### PR TITLE
Add XHR support to Bullet

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -192,6 +192,14 @@ module Bullet
       info
     end
 
+    def text_notifications
+      info = []
+      notification_collector.collection.each do |notification|
+        info << notification.notification_data.values.compact.join("\n")
+      end
+      info
+    end
+
     def warnings
       notification_collector.collection.each_with_object({}) do |notification, warnings|
         warning_type = notification.class.to_s.split(':').last.tableize
@@ -217,6 +225,10 @@ module Bullet
       end
 
       return_value
+    end
+
+    def console_enabled?
+      UniformNotifier.active_notifiers.include?(UniformNotifier::JavascriptConsole)
     end
 
     private

--- a/lib/bullet/bullet_xhr.js
+++ b/lib/bullet/bullet_xhr.js
@@ -1,0 +1,55 @@
+<script language="JavaScript">
+  (function(){
+    var oldOpen = window.XMLHttpRequest.prototype.open;
+    var oldSend = window.XMLHttpRequest.prototype.send;
+    function newOpen(method, url, async, user, password) {
+      this._storedUrl = url;
+      return oldOpen.apply(this, arguments);
+    }
+    function newSend(data) {
+      if (this.onload) {
+        this._storedOnload = this.onload;
+      }
+      this.onload = newOnload;
+      return oldSend.apply(this, arguments);
+    }
+    function newOnload() {
+      if (this._storedUrl.startsWith(window.location.protocol + '//' + window.location.host) ||
+        !this._storedUrl.startsWith("http") // For relative paths
+      ) {
+        var bulletFooterText = this.getResponseHeader("X-bullet-footer-text");
+        if (bulletFooterText) {
+          setTimeout(() => {
+            var oldHtml = document.getElementById("bullet-footer").innerHTML.split("<br>");
+            var header = oldHtml[0]
+            oldHtml = oldHtml.slice(1, oldHtml.length);
+            var newHtml = oldHtml.concat(JSON.parse(bulletFooterText));
+            newHtml = newHtml.slice(newHtml.length - 10, newHtml.length); // rotate through 10 most recent
+            document.getElementById(
+              "bullet-footer"
+            ).innerHTML = `${header}<br>${newHtml.join("<br>")}`;
+          }, 0);
+        }
+        var bulletConsoleText = this.getResponseHeader("X-bullet-console-text");
+        if (bulletConsoleText && typeof(console) !== 'undefined' && console.log) {
+          setTimeout(() => {
+            JSON.parse(bulletConsoleText).forEach(message => {
+              if (console.groupCollapsed && console.groupEnd) {
+                console.groupCollapsed("Uniform Notifier");
+                console.log(message);
+                console.groupEnd();
+              } else {
+                console.log(message);
+              }
+            });
+          }, 0);
+        }
+      }
+      if (this._storedOnload) {
+        return this._storedOnload.apply(this, arguments);
+      }
+    }
+    window.XMLHttpRequest.prototype.open = newOpen;
+    window.XMLHttpRequest.prototype.send = newSend;
+  })();
+</script>

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -58,8 +58,14 @@ module Bullet
       "<div #{footer_div_attributes}>" + footer_header + "<br>" + Bullet.footer_info.uniq.join('<br>') + '</div>'
     end
 
-    def set_header(headers, header_name, footer_info)
-      headers[header_name] = footer_info.to_json
+    def set_header(headers, header_name, header_array)
+      # Many proxy applications such as Nginx and AWS ELB limit
+      # the size a header to 8KB, so truncate the list of reports to
+      # be under that limit
+      while header_array.to_json.length > 8 * 1024
+        header_array.pop
+      end
+      headers[header_name] = header_array.to_json
     end
 
     def file?(headers)

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -17,11 +17,17 @@ module Bullet
       response_body = nil
       if Bullet.notification?
         if !file?(headers) && !sse?(headers) && !empty?(response) &&
-           status == 200 && html_request?(headers, response)
-          response_body = response_body(response)
-          response_body = append_to_html_body(response_body, footer_note) if Bullet.add_footer
-          response_body = append_to_html_body(response_body, Bullet.gather_inline_notifications)
-          headers['Content-Length'] = response_body.bytesize.to_s
+            status == 200
+          if html_request?(headers, response)
+            response_body = response_body(response)
+            response_body = append_to_html_body(response_body, footer_note) if Bullet.add_footer
+            response_body = append_to_html_body(response_body, Bullet.gather_inline_notifications)
+            response_body = append_to_html_body(response_body, xhr_script)
+            headers['Content-Length'] = response_body.bytesize.to_s
+          else
+            set_header(headers, "X-bullet-footer-text", Bullet.footer_info.uniq) if Bullet.add_footer
+            set_header(headers, "X-bullet-console-text", Bullet.text_notifications) if Bullet.console_enabled?
+          end
         end
         Bullet.perform_out_of_channel_notifications(env)
       end
@@ -32,16 +38,10 @@ module Bullet
 
     # fix issue if response's body is a Proc
     def empty?(response)
-      # response may be ["Not Found"], ["Move Permanently"], etc.
-      if rails?
-        (response.is_a?(Array) && response.size <= 1) ||
-          !response.respond_to?(:body) ||
-          !response_body(response).respond_to?(:empty?) ||
-          response_body(response).empty?
-      else
-        body = response_body(response)
-        body.nil? || body.empty?
-      end
+      # response may be ["Not Found"], ["Move Permanently"], etc, but
+      # those should not happen if the status is 200
+      body = response_body(response)
+      body.nil? || body.empty?
     end
 
     def append_to_html_body(response_body, content)
@@ -55,7 +55,11 @@ module Bullet
     end
 
     def footer_note
-      "<div #{footer_div_attributes}>" + footer_close_button + Bullet.footer_info.uniq.join('<br>') + '</div>'
+      "<div #{footer_div_attributes}>" + footer_header + "<br>" + Bullet.footer_info.uniq.join('<br>') + '</div>'
+    end
+
+    def set_header(headers, header_name, footer_info)
+      headers[header_name] = footer_info.to_json
     end
 
     def file?(headers)
@@ -82,7 +86,7 @@ module Bullet
 
     def footer_div_attributes
       <<~EOF
-        data-is-bullet-footer ondblclick="this.parentNode.removeChild(this);" style="position: fixed; bottom: 0pt; left: 0pt; cursor: pointer; border-style: solid; border-color: rgb(153, 153, 153);
+        id="bullet-footer" data-is-bullet-footer ondblclick="this.parentNode.removeChild(this);" style="position: fixed; bottom: 0pt; left: 0pt; cursor: pointer; border-style: solid; border-color: rgb(153, 153, 153);
          -moz-border-top-colors: none; -moz-border-right-colors: none; -moz-border-bottom-colors: none;
          -moz-border-left-colors: none; -moz-border-image: none; border-width: 2pt 2pt 0px 0px;
          padding: 3px 5px; border-radius: 0pt 10pt 0pt 0px; background: none repeat scroll 0% 0% rgba(200, 200, 200, 0.8);
@@ -90,8 +94,18 @@ module Bullet
       EOF
     end
 
-    def footer_close_button
-      "<span onclick='this.parentNode.remove()' style='position:absolute; right: 10px; top: 0px; font-weight: bold; color: #333;'>&times;</span>"
+    def footer_header
+      cancel_button = "<span onclick='this.parentNode.remove()' style='position:absolute; right: 10px; top: 0px; font-weight: bold; color: #333;'>&times;</span>"
+      if Bullet.console_enabled?
+        "<span>See 'Uniform Notifier' in JS Console for Stacktrace</span>#{cancel_button}"
+      else
+        cancel_button
+      end
+    end
+
+    # Make footer work for XHR requests by appending data to the footer
+    def xhr_script
+      File.read("#{File.expand_path(File.dirname(__FILE__))}/bullet_xhr.js")
     end
   end
 end

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -45,9 +45,9 @@ module Bullet
         expect(middleware).not_to be_empty(response)
       end
 
-      it 'should be true if response is not found' do
+      it 'should be false if response is not found' do
         response = ['Not Found']
-        expect(middleware).to be_empty(response)
+        expect(middleware).not_to be_empty(response)
       end
 
       it 'should be true if response body is empty' do
@@ -68,6 +68,7 @@ module Bullet
         it 'should change response body if notification is active' do
           expect(Bullet).to receive(:notification?).and_return(true)
           expect(Bullet).to receive(:gather_inline_notifications).and_return('<bullet></bullet>')
+          expect(middleware).to receive(:xhr_script).and_return('')
           expect(Bullet).to receive(:perform_out_of_channel_notifications)
           status, headers, response = middleware.call('Content-Type' => 'text/html')
           expect(headers['Content-Length']).to eq('56')
@@ -81,7 +82,7 @@ module Bullet
           expect(Bullet).to receive(:notification?).and_return(true)
           expect(Bullet).to receive(:gather_inline_notifications).and_return('<bullet></bullet>')
           status, headers, response = middleware.call('Content-Type' => 'text/html')
-          expect(headers['Content-Length']).to eq('58')
+          expect(headers['Content-Length']).to eq((58 + middleware.send(:xhr_script).length).to_s)
         end
       end
 

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -96,6 +96,14 @@ module Bullet
       end
     end
 
+    context '#set_header' do
+      it 'should truncate headers to under 8kb' do
+        long_header = ['a' * 1024] * 10
+        expected_res = (['a' * 1024] * 7).to_json
+        expect(middleware.set_header({}, 'Dummy-Header', long_header)).to eq(expected_res)
+      end
+    end
+
     describe '#response_body' do
       let(:response) { double }
       let(:body_string) { '<html><body>My Body</body></html>' }


### PR DESCRIPTION
Currently Bullet console and footer warnings only work for html requests
which is a bummer for SinglePageApps and other apps that make heavy use
of AJAX or other XHR requests